### PR TITLE
Fix footer link color scheme in light mode

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -259,3 +259,11 @@ main.dark {
     background-color: #080d15;
 
 }
+a:link{
+    color: #0378fc;
+    text-decoration: none;
+}
+a:visited{
+    color: #0378fc;
+    text-decoration: none;
+}


### PR DESCRIPTION
The link leading to developer's GitHub page white colored in Light Mode, changed the white color to #0378fc in both light and dark mode, for unvisited and visited conditions.

Before change,
![image](https://github.com/user-attachments/assets/180ad15d-de6a-4f84-8857-e0e05d6b1b50)


After change,
![image](https://github.com/user-attachments/assets/1351f433-5609-445d-9b9f-76c978ce7249)

